### PR TITLE
Rework import_post into import_posts with batch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ context/
 public_html_frozen/
 public_html/
 drafts/
+drafts-imported/
 scratch/
 .Trash

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ freeze: # Generate static files
 	@echo "Generating static files.."
 	uv run python application/freeze.py
 	@echo "Done."
+
+import: # Import all drafts/*.md, dump blog.sql, move to drafts-imported/
+	uv run python scripts/import_posts.py
+
+import-one: # Import a single draft (Usage: make import-one POST=path/to/draft.md)
+	@if [ -z "$(POST)" ]; then echo "Usage: make import-one POST=path/to/draft.md" && exit 1; fi
+	uv run python scripts/import_posts.py "$(POST)"
 # -----------------------------------------------------------
 # CAUTION: If you have a file with the same name as make
 # command, you need to add it to .PHONY below, otherwise it

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,11 @@ freeze: # Generate static files
 	@echo "Done."
 
 import: # Import all drafts/*.md, dump blog.sql, move to drafts-imported/
-	uv run python scripts/import_posts.py
+	./scripts/import_posts.py
 
 import-one: # Import a single draft (Usage: make import-one POST=path/to/draft.md)
 	@if [ -z "$(POST)" ]; then echo "Usage: make import-one POST=path/to/draft.md" && exit 1; fi
-	uv run python scripts/import_posts.py "$(POST)"
+	./scripts/import_posts.py "$(POST)"
 # -----------------------------------------------------------
 # CAUTION: If you have a file with the same name as make
 # command, you need to add it to .PHONY below, otherwise it

--- a/README.md
+++ b/README.md
@@ -10,4 +10,19 @@
 * Generate static files: `make freeze`
 * Deployment: Automatic via GitHub Actions on push
 
+## Publishing a post
+
+1. Write a draft markdown file with YAML front-matter in `drafts/`:
+    ```
+    ---
+    slug: my-new-post
+    title: My New Post
+    publish_date: 2026-05-10
+    categories: blog
+    ---
+    Body content here.
+    ```
+2. Import: `make import` (batch — every `drafts/*.md`) or `make import-one POST=drafts/my-new-post.md` (single file). This UPSERTs into the local SQLite DB, dumps the DB to `blog.sql`, and moves the draft to `drafts-imported/<slug>.<timestamp>.md`.
+3. Commit `blog.sql` and push. GitHub Actions handles the freeze and deploy.
+
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 ## Publishing a post
 
-1. Write a draft markdown file with YAML front-matter in `drafts/`:
+1. Scaffold a draft with prefilled front-matter (title, publish_date, default category): `./scripts/generate_empty_template.py my-new-post`. This writes `drafts/my-new-post.md`. Edit the body (and front-matter if needed):
     ```
     ---
-    slug: my-new-post
     title: My New Post
+    slug: my-new-post
     publish_date: 2026-05-10
     categories: blog
     ---

--- a/scripts/generate_empty_template.py
+++ b/scripts/generate_empty_template.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Generate an empty post template for use with import_post.py.
+Generate an empty post template for use with import_posts.py.
 
 Usage:
     ./generate_empty_template.py <slug>
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     import os
 
     parser = argparse.ArgumentParser(
-        description="Generate an empty post template for use with import_post.py."
+        description="Generate an empty post template for use with import_posts.py."
     )
     parser.add_argument("slug", help="Slug for the post")
     parser.add_argument(

--- a/scripts/generate_empty_template.py
+++ b/scripts/generate_empty_template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run python
 """
 Generate an empty post template for use with import_posts.py.
 

--- a/scripts/import_posts.py
+++ b/scripts/import_posts.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
-import sqlite3
+import datetime
 import os
+import shutil
+import sqlite3
 import subprocess
+import sys
+from pathlib import Path
 
 
 def parse_post(filepath):
@@ -42,8 +46,6 @@ def get_category_id(conn, category_name):
 
 
 def normalize_publish_date(date_str):
-    import datetime
-
     try:
         dt = datetime.datetime.strptime(date_str, "%Y-%m-%d")
     except ValueError:
@@ -51,12 +53,13 @@ def normalize_publish_date(date_str):
     return dt.strftime("%Y-%m-%d 00:00:00")
 
 
-def import_post(post_path, db_path):
+def import_post(post_path, conn):
     metadata, markdown_content = parse_post(post_path)
-    conn = sqlite3.connect(db_path)
     cur = conn.cursor()
 
     slug = metadata.get("slug")
+    if not slug:
+        raise ValueError("Front matter missing required 'slug' field")
     if slug.startswith("/"):
         raise ValueError("Slug must not start with a slash")
     cur.execute("SELECT id FROM posts WHERE slug = ?", (slug,))
@@ -85,7 +88,6 @@ def import_post(post_path, db_path):
         )
         post_id = cur.lastrowid
 
-    # Process categories (assume comma-separated if multiple)
     categories = [
         c.strip() for c in metadata.get("categories", "").split(",") if c.strip()
     ]
@@ -97,7 +99,6 @@ def import_post(post_path, db_path):
         )
 
     conn.commit()
-    conn.close()
 
 
 def dump_database(db_path):
@@ -119,14 +120,65 @@ def dump_database(db_path):
         f.write(result)
 
 
-if __name__ == "__main__":
-    import sys
+def collect_drafts(drafts_dir):
+    return sorted(Path(drafts_dir).glob("*.md"))
+
+
+def move_to_imported(draft_path, imported_dir):
+    draft_path = Path(draft_path)
+    imported_dir = Path(imported_dir)
+    imported_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    destination = imported_dir / f"{draft_path.stem}.{timestamp}.md"
+    if destination.exists():
+        raise FileExistsError(
+            f"Refusing to overwrite existing file: {destination}"
+        )
+    shutil.move(str(draft_path), str(destination))
+    return destination
+
+
+def main(argv=None, db_path=None, drafts_dir=None, imported_dir=None):
+    if argv is None:
+        argv = sys.argv[1:]
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    db_path = os.path.join(script_dir, "..", "instance", "blog.db")
-    if len(sys.argv) < 2:
-        print("Usage: {} path-to-post".format(sys.argv[0]))
-        sys.exit(1)
-    post_path = sys.argv[1]
-    import_post(post_path, db_path)
+    if db_path is None:
+        db_path = os.path.join(script_dir, "..", "instance", "blog.db")
+    if drafts_dir is None:
+        drafts_dir = os.path.join(script_dir, "..", "drafts")
+    if imported_dir is None:
+        imported_dir = os.path.join(script_dir, "..", "drafts-imported")
+
+    if argv:
+        drafts = [Path(argv[0])]
+    else:
+        drafts = collect_drafts(drafts_dir)
+
+    if not drafts:
+        print("No drafts to import.")
+        return 0
+
+    conn = sqlite3.connect(db_path)
+    imported = []
+    current = None
+    try:
+        for draft in drafts:
+            current = draft
+            import_post(draft, conn)
+            imported.append(draft)
+    except Exception as e:
+        print(f"Error importing {current}: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
     dump_database(db_path)
+    for draft in imported:
+        move_to_imported(draft, imported_dir)
+    print(f"Imported {len(imported)} post(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import_posts.py
+++ b/scripts/import_posts.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run python
+import argparse
 import datetime
 import os
 import shutil
@@ -138,28 +139,22 @@ def move_to_imported(draft_path, imported_dir):
     return destination
 
 
-def main(argv=None, db_path=None, drafts_dir=None, imported_dir=None):
-    if argv is None:
-        argv = sys.argv[1:]
-
+def main(argv=None):
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    if db_path is None:
-        db_path = os.path.join(script_dir, "..", "instance", "blog.db")
-    if drafts_dir is None:
-        drafts_dir = os.path.join(script_dir, "..", "drafts")
-    if imported_dir is None:
-        imported_dir = os.path.join(script_dir, "..", "drafts-imported")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", nargs="?")
+    parser.add_argument("--db", default=os.path.join(script_dir, "..", "instance", "blog.db"))
+    parser.add_argument("--drafts-dir", default=os.path.join(script_dir, "..", "drafts"))
+    parser.add_argument("--imported-dir", default=os.path.join(script_dir, "..", "drafts-imported"))
+    args = parser.parse_args(argv)
 
-    if argv:
-        drafts = [Path(argv[0])]
-    else:
-        drafts = collect_drafts(drafts_dir)
+    drafts = [Path(args.path)] if args.path else collect_drafts(args.drafts_dir)
 
     if not drafts:
         print("No drafts to import.")
         return 0
 
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(args.db)
     imported = []
     current = None
     try:
@@ -173,9 +168,9 @@ def main(argv=None, db_path=None, drafts_dir=None, imported_dir=None):
     finally:
         conn.close()
 
-    dump_database(db_path)
+    dump_database(args.db)
     for draft in imported:
-        move_to_imported(draft, imported_dir)
+        move_to_imported(draft, args.imported_dir)
     print(f"Imported {len(imported)} post(s).")
     return 0
 

--- a/scripts/import_posts.py
+++ b/scripts/import_posts.py
@@ -134,7 +134,7 @@ def move_to_imported(draft_path, imported_dir):
         raise FileExistsError(
             f"Refusing to overwrite existing file: {destination}"
         )
-    shutil.move(str(draft_path), str(destination))
+    shutil.move(draft_path, destination)
     return destination
 
 

--- a/tests/unit/test_import_posts.py
+++ b/tests/unit/test_import_posts.py
@@ -1,0 +1,344 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import import_posts
+
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "application" / "schema.sql"
+
+
+def _make_db():
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    conn = sqlite3.connect(db_path)
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        conn.executescript(f.read())
+    conn.commit()
+    return db_path, conn
+
+
+def _write_draft(directory, name, slug, title="A Post", date="2026-05-10",
+                 categories="blog", body="Body."):
+    path = Path(directory) / name
+    path.write_text(
+        f"---\nslug: {slug}\ntitle: {title}\npublish_date: {date}\n"
+        f"categories: {categories}\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+class ParsePostTests(unittest.TestCase):
+    def test_with_leading_separator(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write("---\nslug: foo\ntitle: Foo\n---\nBody here.\n")
+            path = f.name
+        try:
+            metadata, content = import_posts.parse_post(path)
+            self.assertEqual(metadata["slug"], "foo")
+            self.assertEqual(metadata["title"], "Foo")
+            self.assertEqual(content, "Body here.")
+        finally:
+            os.unlink(path)
+
+    def test_without_leading_separator(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write("slug: foo\ntitle: Foo\n---\nBody here.\n")
+            path = f.name
+        try:
+            metadata, content = import_posts.parse_post(path)
+            self.assertEqual(metadata["slug"], "foo")
+            self.assertEqual(content, "Body here.")
+        finally:
+            os.unlink(path)
+
+    def test_missing_separator_raises(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write("---\nslug: foo\ntitle: Foo\nNo closer.\n")
+            path = f.name
+        try:
+            with self.assertRaises(Exception):
+                import_posts.parse_post(path)
+        finally:
+            os.unlink(path)
+
+
+class NormalizePublishDateTests(unittest.TestCase):
+    def test_valid(self):
+        self.assertEqual(
+            import_posts.normalize_publish_date("2026-05-10"),
+            "2026-05-10 00:00:00",
+        )
+
+    def test_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            import_posts.normalize_publish_date("May 10, 2026")
+
+
+class GetCategoryIdTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path, self.conn = _make_db()
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db_path)
+
+    def test_creates_when_missing(self):
+        cat_id = import_posts.get_category_id(self.conn, "newcat")
+        self.assertIsNotNone(cat_id)
+        cur = self.conn.cursor()
+        cur.execute("SELECT name FROM categories WHERE id = ?", (cat_id,))
+        self.assertEqual(cur.fetchone()[0], "newcat")
+
+    def test_returns_existing(self):
+        first = import_posts.get_category_id(self.conn, "blog")
+        second = import_posts.get_category_id(self.conn, "blog")
+        self.assertEqual(first, second)
+
+
+class ImportPostTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path, self.conn = _make_db()
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db_path)
+        for f in Path(self.tmpdir).iterdir():
+            f.unlink()
+        os.rmdir(self.tmpdir)
+
+    def test_insert_new_post(self):
+        draft = _write_draft(self.tmpdir, "hello.md", slug="hello",
+                             categories="blog, recipe")
+        import_posts.import_post(draft, self.conn)
+        cur = self.conn.cursor()
+        cur.execute("SELECT title FROM posts WHERE slug='hello'")
+        self.assertEqual(cur.fetchone()[0], "A Post")
+        cur.execute(
+            "SELECT COUNT(*) FROM post_categories pc "
+            "JOIN posts p ON p.id = pc.post_id WHERE p.slug='hello'"
+        )
+        self.assertEqual(cur.fetchone()[0], 2)
+
+    def test_update_replaces_categories(self):
+        draft1 = _write_draft(self.tmpdir, "hello.md", slug="hello",
+                              categories="blog, recipe")
+        import_posts.import_post(draft1, self.conn)
+        draft2 = _write_draft(self.tmpdir, "hello2.md", slug="hello",
+                              title="Updated", categories="til")
+        import_posts.import_post(draft2, self.conn)
+        cur = self.conn.cursor()
+        cur.execute("SELECT title FROM posts WHERE slug='hello'")
+        self.assertEqual(cur.fetchone()[0], "Updated")
+        cur.execute(
+            "SELECT c.name FROM categories c "
+            "JOIN post_categories pc ON pc.category_id = c.id "
+            "JOIN posts p ON p.id = pc.post_id WHERE p.slug='hello'"
+        )
+        names = sorted(r[0] for r in cur.fetchall())
+        self.assertEqual(names, ["til"])
+
+    def test_slug_with_leading_slash_raises(self):
+        draft = _write_draft(self.tmpdir, "bad.md", slug="/badslug")
+        with self.assertRaises(ValueError):
+            import_posts.import_post(draft, self.conn)
+
+    def test_missing_slug_raises(self):
+        draft = Path(self.tmpdir) / "noslug.md"
+        draft.write_text(
+            "---\ntitle: No Slug\npublish_date: 2026-05-10\n---\nBody.\n",
+            encoding="utf-8",
+        )
+        with self.assertRaises(ValueError):
+            import_posts.import_post(draft, self.conn)
+
+
+class CollectDraftsTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        for f in Path(self.tmpdir).rglob("*"):
+            if f.is_file():
+                f.unlink()
+        for d in sorted(Path(self.tmpdir).rglob("*"), reverse=True):
+            if d.is_dir():
+                d.rmdir()
+        os.rmdir(self.tmpdir)
+
+    def test_returns_md_only_sorted(self):
+        (Path(self.tmpdir) / "b.md").write_text("x", encoding="utf-8")
+        (Path(self.tmpdir) / "a.md").write_text("x", encoding="utf-8")
+        (Path(self.tmpdir) / "ignore.txt").write_text("x", encoding="utf-8")
+        result = import_posts.collect_drafts(self.tmpdir)
+        names = [p.name for p in result]
+        self.assertEqual(names, ["a.md", "b.md"])
+
+    def test_no_recursion(self):
+        sub = Path(self.tmpdir) / "sub"
+        sub.mkdir()
+        (sub / "nested.md").write_text("x", encoding="utf-8")
+        (Path(self.tmpdir) / "top.md").write_text("x", encoding="utf-8")
+        result = import_posts.collect_drafts(self.tmpdir)
+        names = [p.name for p in result]
+        self.assertEqual(names, ["top.md"])
+
+
+class MoveToImportedTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.imported = Path(self.tmpdir) / "imported"
+        self.imported.mkdir()
+
+    def tearDown(self):
+        for f in Path(self.tmpdir).rglob("*"):
+            if f.is_file():
+                f.unlink()
+        for d in sorted(Path(self.tmpdir).rglob("*"), reverse=True):
+            if d.is_dir():
+                d.rmdir()
+        os.rmdir(self.tmpdir)
+
+    def test_moves_with_timestamp(self):
+        draft = Path(self.tmpdir) / "foo.md"
+        draft.write_text("x", encoding="utf-8")
+        dest = import_posts.move_to_imported(draft, self.imported)
+        self.assertFalse(draft.exists())
+        self.assertTrue(dest.exists())
+        self.assertTrue(dest.name.startswith("foo."))
+        self.assertTrue(dest.name.endswith(".md"))
+
+    def test_collision_raises(self):
+        draft = Path(self.tmpdir) / "foo.md"
+        draft.write_text("x", encoding="utf-8")
+        fixed = "20260510-213500"
+        with patch("scripts.import_posts.datetime") as mock_dt:
+            mock_dt.datetime.now.return_value.strftime.return_value = fixed
+            import_posts.move_to_imported(draft, self.imported)
+            draft.write_text("y", encoding="utf-8")
+            with self.assertRaises(FileExistsError):
+                import_posts.move_to_imported(draft, self.imported)
+
+
+class DumpDatabaseTests(unittest.TestCase):
+    @patch("scripts.import_posts.subprocess.check_output")
+    def test_invokes_docker(self, mock_check_output):
+        mock_check_output.return_value = "FAKE DUMP\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "blog.db")
+            Path(db_path).touch()
+            old_cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                import_posts.dump_database(db_path)
+                args = mock_check_output.call_args[0][0]
+                self.assertEqual(args[0], "docker")
+                self.assertIn("sqlite3-compat", args)
+                self.assertIn(".dump", args)
+                with open("blog.sql", "r", encoding="utf-8") as f:
+                    self.assertEqual(f.read(), "FAKE DUMP\n")
+            finally:
+                os.chdir(old_cwd)
+
+
+class MainTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path, self.conn = _make_db()
+        self.conn.close()
+        self.tmpdir = tempfile.mkdtemp()
+        self.drafts = Path(self.tmpdir) / "drafts"
+        self.drafts.mkdir()
+        self.imported = Path(self.tmpdir) / "drafts-imported"
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+        for f in Path(self.tmpdir).rglob("*"):
+            if f.is_file():
+                f.unlink()
+        for d in sorted(Path(self.tmpdir).rglob("*"), reverse=True):
+            if d.is_dir():
+                d.rmdir()
+        os.rmdir(self.tmpdir)
+
+    def _run_main(self, argv):
+        old_cwd = os.getcwd()
+        os.chdir(self.tmpdir)
+        try:
+            return import_posts.main(
+                argv,
+                db_path=self.db_path,
+                drafts_dir=str(self.drafts),
+                imported_dir=str(self.imported),
+            )
+        finally:
+            os.chdir(old_cwd)
+
+    @patch("scripts.import_posts.subprocess.check_output")
+    def test_batch_imports_all_and_moves(self, mock_check_output):
+        mock_check_output.return_value = "FAKE\n"
+        _write_draft(self.drafts, "a.md", slug="post-a")
+        _write_draft(self.drafts, "b.md", slug="post-b")
+
+        rc = self._run_main([])
+
+        self.assertEqual(rc, 0)
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute("SELECT slug FROM posts ORDER BY slug")
+        self.assertEqual([r[0] for r in cur.fetchall()],
+                         ["post-a", "post-b"])
+        conn.close()
+
+        moved = sorted(self.imported.iterdir())
+        self.assertEqual(len(moved), 2)
+        self.assertEqual(mock_check_output.call_count, 1)
+
+    @patch("scripts.import_posts.subprocess.check_output")
+    def test_single_path_imports_just_that_file(self, mock_check_output):
+        mock_check_output.return_value = "FAKE\n"
+        draft = _write_draft(self.drafts, "solo.md", slug="solo-post")
+        _write_draft(self.drafts, "other.md", slug="other-post")
+
+        rc = self._run_main([str(draft)])
+
+        self.assertEqual(rc, 0)
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute("SELECT slug FROM posts ORDER BY slug")
+        self.assertEqual([r[0] for r in cur.fetchall()], ["solo-post"])
+        conn.close()
+
+        moved = sorted(self.imported.iterdir())
+        self.assertEqual(len(moved), 1)
+
+    @patch("scripts.import_posts.subprocess.check_output")
+    def test_abort_keeps_committed_skips_remaining_no_dump_no_move(
+        self, mock_check_output
+    ):
+        mock_check_output.return_value = "FAKE\n"
+        _write_draft(self.drafts, "a.md", slug="a")
+        bad = self.drafts / "b.md"
+        bad.write_text("---\nslug: b\ntitle: B\nno-closer\n", encoding="utf-8")
+        _write_draft(self.drafts, "c.md", slug="c")
+
+        rc = self._run_main([])
+
+        self.assertEqual(rc, 1)
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute("SELECT slug FROM posts ORDER BY slug")
+        slugs = [r[0] for r in cur.fetchall()]
+        conn.close()
+        self.assertEqual(slugs, ["a"])
+
+        self.assertFalse(self.imported.exists() and any(self.imported.iterdir()))
+        mock_check_output.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_import_posts.py
+++ b/tests/unit/test_import_posts.py
@@ -250,12 +250,12 @@ class MainTests(unittest.TestCase):
         old_cwd = os.getcwd()
         os.chdir(self.tmpdir)
         try:
-            return import_posts.main(
-                argv,
-                db_path=self.db_path,
-                drafts_dir=str(self.drafts),
-                imported_dir=str(self.imported),
-            )
+            return import_posts.main([
+                "--db", self.db_path,
+                "--drafts-dir", str(self.drafts),
+                "--imported-dir", str(self.imported),
+                *argv,
+            ])
         finally:
             os.chdir(old_cwd)
 

--- a/tests/unit/test_import_posts.py
+++ b/tests/unit/test_import_posts.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sqlite3
 import tempfile
 import unittest
@@ -108,9 +109,7 @@ class ImportPostTests(unittest.TestCase):
     def tearDown(self):
         self.conn.close()
         os.unlink(self.db_path)
-        for f in Path(self.tmpdir).iterdir():
-            f.unlink()
-        os.rmdir(self.tmpdir)
+        shutil.rmtree(self.tmpdir)
 
     def test_insert_new_post(self):
         draft = _write_draft(self.tmpdir, "hello.md", slug="hello",
@@ -163,13 +162,7 @@ class CollectDraftsTests(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp()
 
     def tearDown(self):
-        for f in Path(self.tmpdir).rglob("*"):
-            if f.is_file():
-                f.unlink()
-        for d in sorted(Path(self.tmpdir).rglob("*"), reverse=True):
-            if d.is_dir():
-                d.rmdir()
-        os.rmdir(self.tmpdir)
+        shutil.rmtree(self.tmpdir)
 
     def test_returns_md_only_sorted(self):
         (Path(self.tmpdir) / "b.md").write_text("x", encoding="utf-8")
@@ -196,13 +189,7 @@ class MoveToImportedTests(unittest.TestCase):
         self.imported.mkdir()
 
     def tearDown(self):
-        for f in Path(self.tmpdir).rglob("*"):
-            if f.is_file():
-                f.unlink()
-        for d in sorted(Path(self.tmpdir).rglob("*"), reverse=True):
-            if d.is_dir():
-                d.rmdir()
-        os.rmdir(self.tmpdir)
+        shutil.rmtree(self.tmpdir)
 
     def test_moves_with_timestamp(self):
         draft = Path(self.tmpdir) / "foo.md"
@@ -257,13 +244,7 @@ class MainTests(unittest.TestCase):
 
     def tearDown(self):
         os.unlink(self.db_path)
-        for f in Path(self.tmpdir).rglob("*"):
-            if f.is_file():
-                f.unlink()
-        for d in sorted(Path(self.tmpdir).rglob("*"), reverse=True):
-            if d.is_dir():
-                d.rmdir()
-        os.rmdir(self.tmpdir)
+        shutil.rmtree(self.tmpdir)
 
     def _run_main(self, argv):
         old_cwd = os.getcwd()


### PR DESCRIPTION
## Summary
- Renamed `scripts/import_post.py` → `scripts/import_posts.py`. Now handles both single-file (`import_posts.py PATH`) and batch (`import_posts.py` with no args, processes every `drafts/*.md`).
- On first error: abort, leave the rest unprocessed, no `blog.sql` dump, no draft moves. Already-committed DB rows from earlier in the batch stay (UPSERT means re-running is idempotent).
- On success: dump `blog.sql` once at end, then move each imported draft to `drafts-imported/<stem>.YYYYMMDD-HHMMSS.md`. Filename collision → error (no overwrite).
- Adds `make import` / `make import-one POST=path`, README "Publishing a post" section, `.gitignore` entry for `drafts-imported/`, and full unit coverage (`tests/unit/test_import_posts.py`, 19 new tests).
- Updates two docstring refs in `scripts/generate_empty_template.py`.

## Test plan
- [x] `make test-unit` passes (28/28)
- [x] `make test-integration` passes (3/3, after `make freeze`)
- [x] End-to-end: created a test draft, ran `make import`, verified DB row + `blog.sql` update + timestamped move, then cleaned up.